### PR TITLE
Fix exception handing on WSL

### DIFF
--- a/src/DwarfInstructions.hpp
+++ b/src/DwarfInstructions.hpp
@@ -169,18 +169,6 @@ int DwarfInstructions<A, R>::stepWithDwarf(A &addressSpace, pint_t pc,
       // get pointer to cfa (architecture specific)
       pint_t cfa = getCFA(addressSpace, prolog, registers);
 
-      // Check validity of the CFA.
-      // This is a very dirty hack (inspired by original libunwind version).
-      // Motivation: sometimes libunwind parse wrong value instead of CFA.
-      // We check that memory address belongs to our process by issuing "mincore" syscall.
-      // Actually we don't care if the address is in core or not, we only check return code.
-      // If Address Sanitizer will argue, replace syscall to inline assembly.
-      {
-        unsigned char mincore_res = 0;
-        if (0 != syscall(SYS_mincore, (void*)(cfa / 4096 * 4096), 1, &mincore_res))
-          return UNW_EBADFRAME;
-      }
-
        // restore registers that DWARF says were saved
       R newRegisters = registers;
       pint_t returnAddress = 0;

--- a/src/DwarfInstructions.hpp
+++ b/src/DwarfInstructions.hpp
@@ -15,6 +15,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <errno.h>
 
 #include <unistd.h>
 #include <sys/syscall.h>
@@ -177,7 +178,7 @@ int DwarfInstructions<A, R>::stepWithDwarf(A &addressSpace, pint_t pc,
       // If Address Sanitizer will argue, replace syscall to inline assembly.
       {
         unsigned char mincore_res = 0;
-        if (0 != syscall(SYS_mincore, (void*)(cfa / 4096 * 4096), 1, &mincore_res))
+        if (0 != syscall(SYS_mincore, (void*)(cfa / 4096 * 4096), 1, &mincore_res) && errno != ENOSYS)
           return UNW_EBADFRAME;
       }
 

--- a/src/DwarfInstructions.hpp
+++ b/src/DwarfInstructions.hpp
@@ -169,6 +169,18 @@ int DwarfInstructions<A, R>::stepWithDwarf(A &addressSpace, pint_t pc,
       // get pointer to cfa (architecture specific)
       pint_t cfa = getCFA(addressSpace, prolog, registers);
 
+      // Check validity of the CFA.
+      // This is a very dirty hack (inspired by original libunwind version).
+      // Motivation: sometimes libunwind parse wrong value instead of CFA.
+      // We check that memory address belongs to our process by issuing "mincore" syscall.
+      // Actually we don't care if the address is in core or not, we only check return code.
+      // If Address Sanitizer will argue, replace syscall to inline assembly.
+      {
+        unsigned char mincore_res = 0;
+        if (0 != syscall(SYS_mincore, (void*)(cfa / 4096 * 4096), 1, &mincore_res))
+          return UNW_EBADFRAME;
+      }
+
        // restore registers that DWARF says were saved
       R newRegisters = registers;
       pint_t returnAddress = 0;


### PR DESCRIPTION
This fix makes libunwind working on Windows Subsystem for Linux.
#https://github.com/ClickHouse/ClickHouse/issues/6480

syscall **mincore** on WSL return -1 and breaks exception handing.
I think it is a bad idea to make a syscall while unwinding stack.
compiling with  libstdc++(option USE_LIBCXX) also makes  clickhouse working on WSL.
