### PR TITLE
Fix the case when CFA register is RAX

### DIFF
--- a/src/DwarfInstructions.hpp
+++ b/src/DwarfInstructions.hpp
@@ -65,7 +65,7 @@ private:
 
   static pint_t getCFA(A &addressSpace, const PrologInfo &prolog,
                        const R &registers) {
-    if (prolog.cfaRegister != 0)
+    if (prolog.cfaRegister != (uint32_t)(-1))
       return (pint_t)((sint_t)registers.getRegister((int)prolog.cfaRegister) +
              prolog.cfaRegisterOffset);
     if (prolog.cfaExpression != 0)

--- a/src/DwarfParser.hpp
+++ b/src/DwarfParser.hpp
@@ -401,6 +401,8 @@ bool CFI_Parser<A>::parseFDEInstructions(A &addressSpace,
                                          int arch, PrologInfo *results) {
   // clear results
   memset(results, '\0', sizeof(PrologInfo));
+  results->cfaRegister = (uint32_t)(-1);
+
   PrologInfoStackEntry *rememberStack = NULL;
 
   StackGuard stack;
@@ -591,7 +593,7 @@ bool CFI_Parser<A>::parseInstructions(A &addressSpace, pint_t instructions,
                              results->cfaRegisterOffset);
       break;
     case DW_CFA_def_cfa_expression:
-      results->cfaRegister = 0;
+      results->cfaRegister = (uint32_t)(-1);
       results->cfaExpression = (int64_t)p;
       length = addressSpace.getULEB128(p, instructionsEnd);
       assert(length < static_cast<pint_t>(~0) && "pointer overflow");


### PR DESCRIPTION
LLVMs libunwind refused to work if
```
.cfi_def_cfa_register %rax
```

It triggers assertion if built with assertions or fails in unrelated place if built without assertions.

See https://github.com/openssl/openssl/pull/9624#issuecomment-566259156 for the details.