### PR TITLE
Fix segfaults in UnwindCursor for s390x

### DIFF
--- a/src/UnwindCursor.hpp
+++ b/src/UnwindCursor.hpp
@@ -2703,7 +2703,8 @@ bool UnwindCursor<A, R>::setInfoForSigReturn(Registers_s390x &) {
   struct iovec remote_iov = {reinterpret_cast<void *>(pc), sizeof(inst)};
   long bytesRead =
       syscall(SYS_process_vm_readv, getpid(), &local_iov, 1, &remote_iov, 1, 0);
-
+  if (bytesRead == 0)
+    return false;
   if (inst == 0x0a77 || inst == 0x0aad) {
     _info = {};
     _info.start_ip = pc;

--- a/src/UnwindCursor.hpp
+++ b/src/UnwindCursor.hpp
@@ -2697,7 +2697,13 @@ bool UnwindCursor<A, R>::setInfoForSigReturn(Registers_s390x &) {
   // own restorer function, though, or user-mode QEMU might write a trampoline
   // onto the stack.
   const pint_t pc = static_cast<pint_t>(this->getReg(UNW_REG_IP));
-  const uint16_t inst = _addressSpace.get16(pc);
+  uint16_t inst = 0;
+
+  struct iovec local_iov = {&inst, sizeof(inst)};
+  struct iovec remote_iov = {reinterpret_cast<void *>(pc), sizeof(inst)};
+  long bytesRead =
+      syscall(SYS_process_vm_readv, getpid(), &local_iov, 1, &remote_iov, 1, 0);
+
   if (inst == 0x0a77 || inst == 0x0aad) {
     _info = {};
     _info.start_ip = pc;


### PR DESCRIPTION
This PR fixes ClickHouse random crashes in s390x. The root of cause is the same as described in:

https://reviews.llvm.org/rG0be0a53df65cb402359c257922d80ab93d86fb40

> [libunwind] Use process_vm_readv to avoid potential segfaults
> 
> We've observed segfaults in libunwind when attempting to check for the
> Linux aarch64 sigreturn frame, presumably because of bad unwind info
> leading to an incorrect PC that we attempt to read from. Use
> process_vm_readv to read the memory safely instead.
> 
> The s390x code path should likely follow suit, but I don't have the
> hardware to be able to test that, so I didn't modify it here either.
> 
> Reviewed By: MaskRay, rprichard, #libunwind

The PR applied similar fix for s390x.
