### PR TITLE
Exceptions do not work in ClickHouse integrated to AWS Lambda

### DIFF
--- a/src/DwarfInstructions.hpp
+++ b/src/DwarfInstructions.hpp
@@ -101,7 +101,7 @@ static bool isPointerValid(pint_t ptr)
 {
   unsigned char mincore_res = 0;
   auto page_size = sysconf(_SC_PAGESIZE);
-  return ptr && (0 == syscall(SYS_mincore, (void*)(ptr / page_size * page_size), 1, &mincore_res) || errno == ENOSYS);
+  return ptr && (0 == syscall(SYS_mincore, (void*)(ptr / page_size * page_size), 1, &mincore_res) || errno == ENOSYS || errno == EPERM);
 }
 
 template <typename A, typename R>


### PR DESCRIPTION
`libunwind` fails to find an exception handler if the application is running within an AWS Lambda container.

The issue stems from a `mincore` call when checking the validity of the CFA pointer in `libunwind/src/DwarfInstructions.hpp:isPointerValid`. This system call is prohibited within the scope of the AWS Lambda environment, resulting in an `EPERM` error.

A workaround is to add a check for the `EPERM` errno to `isPointerValid` function. This disables CFA validity checks, but it appears to be the only viable option for AWS Lambda.

**Steps to reproduce the issue**

1. Add the following code to `main` function in `ClickHouse/programs/main.cpp` (it does not implement a Lambda handler, but it is not necessary to reproduce the issue):
```cpp
    try
    {
        std::cout << "main: About to throw exception" << std::endl;
        throw std::runtime_error("Exception");
    }
    catch (const std::exception& e)
    {
        std::cout << "main: Caught exception: " << e.what() << std::endl;
    }
```
2. Build a Docker image using the following `Dockerfile`:
```
FROM public.ecr.aws/lambda/provided:al2023
COPY clickhouse-local /var/task
ENTRYPOINT [ "/var/task/clickhouse-local" ]
```
3. Upload the image to AWS ECR.
4. Create a Lambda function using the image.
5. Execute a test event.

**Result**

Logs show error: 

```
main: About to throw exception 
libc++abi: terminating due to uncaught exception of type std::runtime_error: Exception 
INIT_REPORT Init Duration: 5150.41 ms	Phase: init	Status: error	Error Type: Runtime.ExitError 
```
The issue has been reproduced in `us-east-2` AWS region. There is a possibility that other regions may have different settings where the problem does not manifest.