### PR TITLE
Fix unwind from signal handler

### DIFF
--- a/src/DwarfInstructions.hpp
+++ b/src/DwarfInstructions.hpp
@@ -359,7 +359,12 @@ int DwarfInstructions<A, R>::stepWithDwarf(A &addressSpace, pint_t pc,
 
       // Return address is address after call site instruction, so setting IP to
       // that does simualates a return.
-      newRegisters.setIP(returnAddress);
+      //
+      // In case of this is frame of signal handler, the IP should be
+      // incremented, because the IP saved in the signal handler points to
+      // first non-executed instruction, while FDE/CIE expects IP to be after
+      // the first non-executed instruction.
+      newRegisters.setIP(returnAddress + cieInfo.isSignalFrame);
 
       // Simulate the step by replacing the register set with the new ones.
       registers = newRegisters;


### PR DESCRIPTION
In case of this is frame of signal handler, the IP should be incremented, because the IP saved in the signal handler points to first non-executed instruction, while FDE/CIE expects IP to be after the first non-executed instruction.

PR in upstream: https://github.com/llvm/llvm-project/pull/92291