### PR TITLE
Fix a suspected off-by-one error in parseFDEInstructions()

### DIFF
--- a/src/DwarfParser.hpp
+++ b/src/DwarfParser.hpp
@@ -453,7 +453,7 @@ bool CFI_Parser<A>::parseFDEInstructions(A &addressSpace,
                            static_cast<uint64_t>(instructionsEnd));
 
     // see DWARF Spec, section 6.4.2 for details on unwind opcodes
-    while ((p < instructionsEnd) && (codeOffset < pcoffset)) {
+    while ((p < instructionsEnd) && (codeOffset <= pcoffset)) {
       uint64_t reg;
       uint64_t reg2;
       int64_t offset;

--- a/src/DwarfParser.hpp
+++ b/src/DwarfParser.hpp
@@ -100,26 +100,26 @@ public:
         cfaRegister = (uint32_t)(-1);
       }
     }
-    void checkSaveRegister(uint64_t reg, PrologInfo &initialState) {
-      if (!savedRegisters[reg].initialStateSaved) {
+    void checkSaveRegister(uint64_t reg, PrologInfo &initialState, bool save) {
+      if (save && !savedRegisters[reg].initialStateSaved) {
         initialState.savedRegisters[reg] = savedRegisters[reg];
         savedRegisters[reg].initialStateSaved = true;
       }
     }
     void setRegister(uint64_t reg, RegisterSavedWhere newLocation,
-                     int64_t newValue, PrologInfo &initialState) {
-      checkSaveRegister(reg, initialState);
+                     int64_t newValue, PrologInfo &initialState, bool save) {
+      checkSaveRegister(reg, initialState, save);
       savedRegisters[reg].location = newLocation;
       savedRegisters[reg].value = newValue;
     }
     void setRegisterLocation(uint64_t reg, RegisterSavedWhere newLocation,
-                             PrologInfo &initialState) {
-      checkSaveRegister(reg, initialState);
+                             PrologInfo &initialState, bool save) {
+      checkSaveRegister(reg, initialState, save);
       savedRegisters[reg].location = newLocation;
     }
     void setRegisterValue(uint64_t reg, int64_t newValue,
-                          PrologInfo &initialState) {
-      checkSaveRegister(reg, initialState);
+                          PrologInfo &initialState, bool save) {
+      checkSaveRegister(reg, initialState, save);
       savedRegisters[reg].value = newValue;
     }
     void restoreRegisterToInitialState(uint64_t reg, PrologInfo &initialState) {
@@ -430,18 +430,20 @@ bool CFI_Parser<A>::parseFDEInstructions(A &addressSpace,
     pint_t instructions;
     pint_t instructionsEnd;
     pint_t pcoffset;
+    bool save;
   };
 
   ParseInfo parseInfoArray[] = {
       {cieInfo.cieInstructions, cieInfo.cieStart + cieInfo.cieLength,
-       (pint_t)(-1)},
+       (pint_t)(-1), false},
       {fdeInfo.fdeInstructions, fdeInfo.fdeStart + fdeInfo.fdeLength,
-       upToPC - fdeInfo.pcStart}};
+       upToPC - fdeInfo.pcStart, true}};
 
   for (const auto &info : parseInfoArray) {
     pint_t p = info.instructions;
     pint_t instructionsEnd = info.instructionsEnd;
     pint_t pcoffset = info.pcoffset;
+    bool save = info.save;
     pint_t codeOffset = 0;
 
     // initialState initialized as registers in results are modified. Use
@@ -498,7 +500,7 @@ bool CFI_Parser<A>::parseFDEInstructions(A &addressSpace,
               "malformed DW_CFA_offset_extended DWARF unwind, reg too big");
           return false;
         }
-        results->setRegister(reg, kRegisterInCFA, offset, initialState);
+        results->setRegister(reg, kRegisterInCFA, offset, initialState, save);
         _LIBUNWIND_TRACE_DWARF("DW_CFA_offset_extended(reg=%" PRIu64 ", "
                                "offset=%" PRId64 ")\n",
                                reg, offset);
@@ -521,7 +523,7 @@ bool CFI_Parser<A>::parseFDEInstructions(A &addressSpace,
               "malformed DW_CFA_undefined DWARF unwind, reg too big");
           return false;
         }
-        results->setRegisterLocation(reg, kRegisterUndefined, initialState);
+        results->setRegisterLocation(reg, kRegisterUndefined, initialState, save);
         _LIBUNWIND_TRACE_DWARF("DW_CFA_undefined(reg=%" PRIu64 ")\n", reg);
         break;
       case DW_CFA_same_value:
@@ -535,7 +537,7 @@ bool CFI_Parser<A>::parseFDEInstructions(A &addressSpace,
         // "same value" means register was stored in frame, but its current
         // value has not changed, so no need to restore from frame.
         // We model this as if the register was never saved.
-        results->setRegisterLocation(reg, kRegisterUnused, initialState);
+        results->setRegisterLocation(reg, kRegisterUnused, initialState, save);
         _LIBUNWIND_TRACE_DWARF("DW_CFA_same_value(reg=%" PRIu64 ")\n", reg);
         break;
       case DW_CFA_register:
@@ -552,7 +554,7 @@ bool CFI_Parser<A>::parseFDEInstructions(A &addressSpace,
           return false;
         }
         results->setRegister(reg, kRegisterInRegister, (int64_t)reg2,
-                             initialState);
+                             initialState, save);
         _LIBUNWIND_TRACE_DWARF(
             "DW_CFA_register(reg=%" PRIu64 ", reg2=%" PRIu64 ")\n", reg, reg2);
         break;
@@ -630,7 +632,7 @@ bool CFI_Parser<A>::parseFDEInstructions(A &addressSpace,
           return false;
         }
         results->setRegister(reg, kRegisterAtExpression, (int64_t)p,
-                             initialState);
+                             initialState, save);
         length = addressSpace.getULEB128(p, instructionsEnd);
         assert(length < static_cast<pint_t>(~0) && "pointer overflow");
         p += static_cast<pint_t>(length);
@@ -648,7 +650,7 @@ bool CFI_Parser<A>::parseFDEInstructions(A &addressSpace,
         }
         offset = addressSpace.getSLEB128(p, instructionsEnd) *
                  cieInfo.dataAlignFactor;
-        results->setRegister(reg, kRegisterInCFA, offset, initialState);
+        results->setRegister(reg, kRegisterInCFA, offset, initialState, save);
         _LIBUNWIND_TRACE_DWARF("DW_CFA_offset_extended_sf(reg=%" PRIu64 ", "
                                "offset=%" PRId64 ")\n",
                                reg, offset);
@@ -686,7 +688,7 @@ bool CFI_Parser<A>::parseFDEInstructions(A &addressSpace,
         }
         offset = (int64_t)addressSpace.getULEB128(p, instructionsEnd) *
                  cieInfo.dataAlignFactor;
-        results->setRegister(reg, kRegisterOffsetFromCFA, offset, initialState);
+        results->setRegister(reg, kRegisterOffsetFromCFA, offset, initialState, save);
         _LIBUNWIND_TRACE_DWARF("DW_CFA_val_offset(reg=%" PRIu64 ", "
                                "offset=%" PRId64 "\n",
                                reg, offset);
@@ -700,7 +702,7 @@ bool CFI_Parser<A>::parseFDEInstructions(A &addressSpace,
         }
         offset = addressSpace.getSLEB128(p, instructionsEnd) *
                  cieInfo.dataAlignFactor;
-        results->setRegister(reg, kRegisterOffsetFromCFA, offset, initialState);
+        results->setRegister(reg, kRegisterOffsetFromCFA, offset, initialState, save);
         _LIBUNWIND_TRACE_DWARF("DW_CFA_val_offset_sf(reg=%" PRIu64 ", "
                                "offset=%" PRId64 "\n",
                                reg, offset);
@@ -713,7 +715,7 @@ bool CFI_Parser<A>::parseFDEInstructions(A &addressSpace,
           return false;
         }
         results->setRegister(reg, kRegisterIsExpression, (int64_t)p,
-                             initialState);
+                             initialState, save);
         length = addressSpace.getULEB128(p, instructionsEnd);
         assert(length < static_cast<pint_t>(~0) && "pointer overflow");
         p += static_cast<pint_t>(length);
@@ -736,7 +738,7 @@ bool CFI_Parser<A>::parseFDEInstructions(A &addressSpace,
         }
         offset = (int64_t)addressSpace.getULEB128(p, instructionsEnd) *
                  cieInfo.dataAlignFactor;
-        results->setRegister(reg, kRegisterInCFA, -offset, initialState);
+        results->setRegister(reg, kRegisterInCFA, -offset, initialState, save);
         _LIBUNWIND_TRACE_DWARF(
             "DW_CFA_GNU_negative_offset_extended(%" PRId64 ")\n", offset);
         break;
@@ -754,7 +756,7 @@ bool CFI_Parser<A>::parseFDEInstructions(A &addressSpace,
           int64_t value =
               results->savedRegisters[UNW_AARCH64_RA_SIGN_STATE].value ^ 0x1;
           results->setRegisterValue(UNW_AARCH64_RA_SIGN_STATE, value,
-                                    initialState);
+                                    initialState, save);
           _LIBUNWIND_TRACE_DWARF("DW_CFA_AARCH64_negate_ra_state\n");
         } break;
 #endif
@@ -766,13 +768,13 @@ bool CFI_Parser<A>::parseFDEInstructions(A &addressSpace,
           for (reg = UNW_SPARC_O0; reg <= UNW_SPARC_O7; reg++) {
             results->setRegister(reg, kRegisterInRegister,
                                  ((int64_t)reg - UNW_SPARC_O0) + UNW_SPARC_I0,
-                                 initialState);
+                                 initialState, save);
           }
 
           for (reg = UNW_SPARC_L0; reg <= UNW_SPARC_I7; reg++) {
             results->setRegister(reg, kRegisterInCFA,
                                  ((int64_t)reg - UNW_SPARC_L0) * 4,
-                                 initialState);
+                                 initialState, save);
           }
           break;
 #endif
@@ -788,12 +790,12 @@ bool CFI_Parser<A>::parseFDEInstructions(A &addressSpace,
               results->setRegister(
                   reg, kRegisterInCFADecrypt,
                   static_cast<int64_t>((reg - UNW_SPARC_L0) * sizeof(pint_t)),
-                  initialState);
+                  initialState, save);
             else
               results->setRegister(
                   reg, kRegisterInCFA,
                   static_cast<int64_t>((reg - UNW_SPARC_L0) * sizeof(pint_t)),
-                  initialState);
+                  initialState, save);
           }
           _LIBUNWIND_TRACE_DWARF("DW_CFA_GNU_window_save\n");
           break;
@@ -818,7 +820,7 @@ bool CFI_Parser<A>::parseFDEInstructions(A &addressSpace,
           }
           offset = (int64_t)addressSpace.getULEB128(p, instructionsEnd) *
                    cieInfo.dataAlignFactor;
-          results->setRegister(reg, kRegisterInCFA, offset, initialState);
+          results->setRegister(reg, kRegisterInCFA, offset, initialState, save);
           _LIBUNWIND_TRACE_DWARF("DW_CFA_offset(reg=%d, offset=%" PRId64 ")\n",
                                  operand, offset);
           break;


### PR DESCRIPTION
We get segfaults in libunwind often, especially on aarch64. From reproducing and investigating https://github.com/ClickHouse/ClickHouse/issues/64915 , the cause of the crash, in that specific instance, is what this PR changes - off-by-one error (?) when determining which unwind info entry's address range covers the current instruction address. Details in the next section.

But this is very suspicious because this is hot code, and not ARM-specific. And there seems to be another bug in how `initialState` is used (it can be used-after-free if a register is saved/loaded on different iterations of the outer loop). I would've expected unwinding to crash or produce garbage much more often if this were really broken. Maybe compilers emit these ranges incorrectly on x86 but correctly on ARM (always or sometimes)? Maybe the code was supposed to add/subtract one somewhere else (but I checked and it doesn't look so)? Maybe I'm reading the wrong standard (.eh_frame vs .debug_frame?), and the two standards are mostly the same but are off-by-one from each other (that would be so weird, but DWARF is weird)? Maybe the off-by-one is much more likely to crash the program on ARM because return address works differently (there's `lr` register)? I'm confused.

I guess let's run this in CI and see if it super-breaks.

---

Details:

From https://dwarfstd.org/doc/DWARF5.pdf :
> 6.4.3 Call Frame Instruction Usage
> To determine the virtual unwind rule set for a given location (L1), search through the
> FDE headers looking at the initial_location and address_range values to see if L1
> is contained in the FDE. If so, then:
> 1. Initialize a register set by reading the initial_instructions field of the associated
> CIE. Set L2 to the value of the initial_location field from the FDE header.
> 2. Read and process the FDE’s instruction sequence until a DW_CFA_advance_loc,
> DW_CFA_set_loc, or the end of the instruction stream is encountered.
> 3. If a DW_CFA_advance_loc or DW_CFA_set_loc instruction is encountered, then
> compute a new location value (L2). If L1 ≥ L2 then process the instruction and go
> back to step 2.
> 4. The end of the instruction stream can be thought of as a DW_CFA_set_loc
> (initial_location + address_range) instruction. Note that the FDE is
> ill-formed if L2 is less than L1.
>
> The rules in the register set now apply to location L1.
> For an example, see Appendix D.6 on page 325.

(Notice the '≥', while the code had effectively '>'.)
(The example in Appendix D.6 looks consistent with this understanding as well.)

In this case, the address is 0xbc3b924, CIE and FDE are:
```
00d4f37c 000000000000001c 00000000 CIE
  Version:               1
  Augmentation:          "zPLR"
  Code alignment factor: 1
  Data alignment factor: -4
  Return address column: 30
  Augmentation data:     9c 31 84 a1 0f 00 00 00 00 1c 1b
  DW_CFA_def_cfa: r31 (sp) ofs 0

0100b1cc 0000000000000034 002bbe54 FDE cie=00d4f37c pc=000000000bc3b8c0..000000000bc3b998
  Augmentation data:     67 5f 76 fb ff ff ff ff
  DW_CFA_advance_loc: 4 to 000000000bc3b8c4
  DW_CFA_def_cfa_offset: 80
  DW_CFA_advance_loc: 12 to 000000000bc3b8d0
  DW_CFA_def_cfa: r29 (x29) ofs 32
  DW_CFA_offset: r19 (x19) at cfa-8
  DW_CFA_offset: r20 (x20) at cfa-16
  DW_CFA_offset: r30 (x30) at cfa-24
  DW_CFA_offset: r29 (x29) at cfa-32
  DW_CFA_remember_state
  DW_CFA_advance_loc1: 72 to 000000000bc3b918
  DW_CFA_def_cfa: r31 (sp) ofs 80
  DW_CFA_advance_loc: 12 to 000000000bc3b924
  DW_CFA_def_cfa_offset: 0
  DW_CFA_restore: r19 (x19)
  DW_CFA_restore: r20 (x20)
  DW_CFA_restore: r30 (x30)
  DW_CFA_restore: r29 (x29)
  DW_CFA_advance_loc: 4 to 000000000bc3b928
  DW_CFA_restore_state
  DW_CFA_nop
```

Code is:
```
Dump of assembler code for function _ZN2DB12_GLOBAL__N_18readULEBERNSt3__117basic_string_viewIcNS1_11char_traitsIcEEEERhS7_:
   0x000000000bc3b8c0 <+0>:     sub     sp, sp, #0x50

   0x000000000bc3b8c4 <+4>:     stp     x29, x30, [sp, #48]
   0x000000000bc3b8c8 <+8>:     stp     x20, x19, [sp, #64]
   0x000000000bc3b8cc <+12>:    add     x29, sp, #0x30

   0x000000000bc3b8d0 <+16>:    mov     x8, xzr
   0x000000000bc3b8d4 <+20>:    strb    wzr, [x1]
   0x000000000bc3b8d8 <+24>:    ldr     x9, [x0, #8]
   0x000000000bc3b8dc <+28>:    cbz     x9, 0xbc3b928 <_ZN2DB12_GLOBAL__N_18readULEBERNSt3__117basic_string_viewIcNS1_11char_traitsIcEEEERhS7_+104>
   0x000000000bc3b8e0 <+32>:    ldr     x10, [x0]
   0x000000000bc3b8e4 <+36>:    sub     x9, x9, #0x1
   0x000000000bc3b8e8 <+40>:    ldrb    w11, [x10], #1
   0x000000000bc3b8ec <+44>:    stp     x10, x9, [x0]
   0x000000000bc3b8f0 <+48>:    strb    w11, [x2]
   0x000000000bc3b8f4 <+52>:    and     x11, x11, #0x7f
   0x000000000bc3b8f8 <+56>:    ldrb    w9, [x1]
   0x000000000bc3b8fc <+60>:    add     w10, w9, #0x7
   0x000000000bc3b900 <+64>:    lsl     x9, x11, x9
   0x000000000bc3b904 <+68>:    strb    w10, [x1]
   0x000000000bc3b908 <+72>:    ldrsb   w10, [x2]
   0x000000000bc3b90c <+76>:    orr     x8, x9, x8
   0x000000000bc3b910 <+80>:    tbnz    w10, #31, 0xbc3b8d8 <_ZN2DB12_GLOBAL__N_18readULEBERNSt3__117basic_string_viewIcNS1_11char_traitsIcEEEERhS7_+24>
   0x000000000bc3b914 <+84>:    mov     x0, x8

   0x000000000bc3b918 <+88>:    ldp     x20, x19, [sp, #64]
   0x000000000bc3b91c <+92>:    ldp     x29, x30, [sp, #48]
   0x000000000bc3b920 <+96>:    add     sp, sp, #0x50

   0x000000000bc3b924 <+100>:   ret

   0x000000000bc3b928 <+104>:   mov     x20, x0
   0x000000000bc3b92c <+108>:   mov     w0, #0x178                      // #376
   0x000000000bc3b930 <+112>:   bl      0xe5b4d54 <__AArch64ADRPThunk___cxa_allocate_exception>
   0x000000000bc3b934 <+116>:   adrp    x8, 0x20db000
   0x000000000bc3b938 <+120>:   add     x8, x8, #0x1fc
   0x000000000bc3b93c <+124>:   mov     w9, #0x2a                       // #42
   0x000000000bc3b940 <+128>:   stp     x8, x9, [sp, #16]
   0x000000000bc3b944 <+132>:   mov     x19, x0
   0x000000000bc3b948 <+136>:   stp     x8, x9, [sp, #32]
   0x000000000bc3b94c <+140>:   ldr     x9, [x20, #8]
   0x000000000bc3b950 <+144>:   mov     w8, #0x1                        // #1
   0x000000000bc3b954 <+148>:   stp     x9, x8, [sp]
   0x000000000bc3b958 <+152>:   add     x2, sp, #0x10
   0x000000000bc3b95c <+156>:   add     x3, sp, #0x8
   0x000000000bc3b960 <+160>:   mov     x4, sp
   0x000000000bc3b964 <+164>:   mov     w1, #0x1d1                      // #465
   0x000000000bc3b968 <+168>:   bl      0xbc0c8a0 <_ZN2DB9ExceptionC2IJmmEEEi22FormatStringHelperImplIJDpNSt3__113type_identityIT_E4typeEEEDpOS5_>
   0x000000000bc3b96c <+172>:   adrp    x1, 0x153e7000 <_ZN12_GLOBAL__N_123clickhouse_applicationsE+448>
   0x000000000bc3b970 <+176>:   add     x1, x1, #0x158
   0x000000000bc3b974 <+180>:   adrp    x2, 0x7aa2000 <_ZNK2DB24FunctionStringOrArrayToTINS_12_GLOBAL__N_118CRCFunctionWrapperIN12_GLOBAL__N_113CRC32ZLibImplEEES4_jLb1EE11executeImplERKNSt3__16vectorINS_21ColumnWithTypeAndNameENS7_9allocatorIS9_EEEERKNS7_10shared_ptrIKNS_9IDataTypeEEEm.3e570ba5df68adedf72ec05448f83d40+1120>
   0x000000000bc3b978 <+184>:   add     x2, x2, #0xfc0
   0x000000000bc3b97c <+188>:   mov     x0, x19
   0x000000000bc3b980 <+192>:   bl      0xe5b4d58 <__AArch64ADRPThunk___cxa_throw>
   0x000000000bc3b984 <+196>:   mov     x20, x0
   0x000000000bc3b988 <+200>:   sub     x0, x19, #0x80
   0x000000000bc3b98c <+204>:   bl      0xe5b51cc <__AArch64ADRPThunk__ZN10__cxxabiv128__aligned_free_with_fallbackEPv>
   0x000000000bc3b990 <+208>:   mov     x0, x20
   0x000000000bc3b994 <+212>:   bl      0xe5b4c80 <__AArch64ADRPThunk__Unwind_Resume>
End of assembler dump.
```

Clearly the unwind commands
```
  DW_CFA_def_cfa_offset: 0
  DW_CFA_restore: r19 (x19)
  DW_CFA_restore: r20 (x20)
  DW_CFA_restore: r30 (x30)
  DW_CFA_restore: r29 (x29)
```
are supposed to apply when instruction pointer is at bc3b924 (i.e. the `add     sp, sp, #0x50` has happened, but `ret` hasn't). I stepped through the code and checked that libunwind doesn't apply these commands because of the `>`.