### PR TITLE
Fix unwind from signal handler on ARM

### DIFF
--- a/src/DwarfInstructions.hpp
+++ b/src/DwarfInstructions.hpp
@@ -381,10 +381,13 @@ int DwarfInstructions<A, R>::stepWithDwarf(A &addressSpace, pint_t pc,
       // Return address is address after call site instruction, so setting IP to
       // that simulates a return.
       //
-      // In case of this is frame of signal handler, the IP should be
-      // incremented, because the IP saved in the signal handler points to
-      // first non-executed instruction, while FDE/CIE expects IP to be after
-      // the first non-executed instruction.
+      // The +-1 situation is subtle.
+      // Return address points to the next instruction after the `call`
+      // instruction, but logically we're "inside" the call instruction, and
+      // FDEs are constructed accordingly.
+      // So our FDE parsing implicitly subtracts 1 from the address.
+      // But for signal return, there's no `call` instruction, and
+      // subtracting 1 would be incorrect. So we add 1 here to compensate.
       newRegisters.setIP(returnAddress + cieInfo.isSignalFrame);
 
       // Simulate the step by replacing the register set with the new ones.

--- a/src/DwarfParser.hpp
+++ b/src/DwarfParser.hpp
@@ -452,7 +452,14 @@ bool CFI_Parser<A>::parseFDEInstructions(A &addressSpace,
                            ")\n",
                            static_cast<uint64_t>(instructionsEnd));
 
-    // see DWARF Spec, section 6.4.2 for details on unwind opcodes
+    // see DWARF Spec, section 6.4.2 for details on unwind opcodes;
+    //
+    // Note that we're looking for the PrologInfo for address `codeOffset - 1`,
+    // hence '<' instead of '<=" in `codeOffset < pcoffset`
+    // (compare to DWARF Spec section 6.4.3 "Call Frame Instruction Usage").
+    // The -1 accounts for the fact that function return address points to the
+    // next instruction *after* the `call` instruction, while control is
+    // logically "inside" the `call` instruction.
     while ((p < instructionsEnd) && (codeOffset < pcoffset)) {
       uint64_t reg;
       uint64_t reg2;

--- a/src/UnwindCursor.hpp
+++ b/src/UnwindCursor.hpp
@@ -2760,7 +2760,15 @@ int UnwindCursor<A, R>::stepThroughSigReturn(Registers_arm64 &) {
     _registers.setRegister(UNW_AARCH64_X0 + i, value);
   }
   _registers.setSP(_addressSpace.get64(sigctx + kOffsetSp));
-  _registers.setIP(_addressSpace.get64(sigctx + kOffsetPc));
+
+  // The +1 story is the same as in DwarfInstructions::stepWithDwarf()
+  // (search for "returnAddress + cieInfo.isSignalFrame" or "Return address points to the next instruction").
+  // This is probably not the right place for this because this function is not necessarily used
+  // with DWARF. Need to research whether the other unwind methods have the same +-1 situation or
+  // are off by one.
+  pint_t returnAddress = _addressSpace.get64(sigctx + kOffsetPc);
+  _registers.setIP(returnAddress + 1);
+
   _isSignalFrame = true;
   return UNW_STEP_SUCCESS;
 }


### PR DESCRIPTION
Same fix as in https://github.com/ClickHouse/libunwind/pull/25 , but for the other code path that unwinds from signal handler.

https://github.com/ClickHouse/libunwind/pull/27 was incorrect because I didn't understand that the comparison was intentionally off-by-one, to implicitly subtract 1 from the address. Added a comment about it. I wish this -1 was (a) explicit, (b) skipped for signal return (instead of adding 1, then implicitly subtracting it).

Not upstreamable in current state because maybe-DWARF-specific code (with DWARF-specific comment at least) is in non-DWARF-specific part of the code. Need to figure out which of the unwind methods need this +1 and enable it for those. There's also a `--pc` in `setInfoBasedOnIPRegister()` which plays a similar role and should maybe be unified with all the other explicit and implicit +-1s. It's too much mess to clean up, I probably won't do it. This is probably good enough for clickhouse, we don't use all those other unwinding methods.