### PR TITLE
Reapply patch to fix SIGSEGV in case of unwind from signal handler (should be aarch64-safe)

### DIFF
--- a/src/DwarfInstructions.hpp
+++ b/src/DwarfInstructions.hpp
@@ -379,13 +379,8 @@ int DwarfInstructions<A, R>::stepWithDwarf(A &addressSpace, pint_t pc,
 #endif
 
       // Return address is address after call site instruction, so setting IP to
-      // that simulates a return.
-      //
-      // In case of this is frame of signal handler, the IP should be
-      // incremented, because the IP saved in the signal handler points to
-      // first non-executed instruction, while FDE/CIE expects IP to be after
-      // the first non-executed instruction.
-      newRegisters.setIP(returnAddress + cieInfo.isSignalFrame);
+      // that does simulates a return.
+      newRegisters.setIP(returnAddress);
 
       // Simulate the step by replacing the register set with the new ones.
       registers = newRegisters;

--- a/src/DwarfInstructions.hpp
+++ b/src/DwarfInstructions.hpp
@@ -381,13 +381,10 @@ int DwarfInstructions<A, R>::stepWithDwarf(A &addressSpace, pint_t pc,
       // Return address is address after call site instruction, so setting IP to
       // that simulates a return.
       //
-      // The +-1 situation is subtle.
-      // Return address points to the next instruction after the `call`
-      // instruction, but logically we're "inside" the call instruction, and
-      // FDEs are constructed accordingly.
-      // So our FDE parsing implicitly subtracts 1 from the address.
-      // But for signal return, there's no `call` instruction, and
-      // subtracting 1 would be incorrect. So we add 1 here to compensate.
+      // In case of this is frame of signal handler, the IP should be
+      // incremented, because the IP saved in the signal handler points to
+      // first non-executed instruction, while FDE/CIE expects IP to be after
+      // the first non-executed instruction.
       newRegisters.setIP(returnAddress + cieInfo.isSignalFrame);
 
       // Simulate the step by replacing the register set with the new ones.

--- a/src/DwarfParser.hpp
+++ b/src/DwarfParser.hpp
@@ -452,14 +452,7 @@ bool CFI_Parser<A>::parseFDEInstructions(A &addressSpace,
                            ")\n",
                            static_cast<uint64_t>(instructionsEnd));
 
-    // see DWARF Spec, section 6.4.2 for details on unwind opcodes;
-    //
-    // Note that we're looking for the PrologInfo for address `codeOffset - 1`,
-    // hence '<' instead of '<=" in `codeOffset < pcoffset`
-    // (compare to DWARF Spec section 6.4.3 "Call Frame Instruction Usage").
-    // The -1 accounts for the fact that function return address points to the
-    // next instruction *after* the `call` instruction, while control is
-    // logically "inside" the `call` instruction.
+    // see DWARF Spec, section 6.4.2 for details on unwind opcodes
     while ((p < instructionsEnd) && (codeOffset < pcoffset)) {
       uint64_t reg;
       uint64_t reg2;

--- a/src/UnwindCursor.hpp
+++ b/src/UnwindCursor.hpp
@@ -2605,6 +2605,14 @@ void UnwindCursor<A, R>::setInfoBasedOnIPRegister(bool isReturnAddress) {
     --pc;
 #endif
 
+#if !(defined(_LIBUNWIND_SUPPORT_SEH_UNWIND) && defined(_WIN32))
+  // In case of this is frame of signal handler, the IP saved in the signal
+  // handler points to first non-executed instruction, while FDE/CIE expects IP
+  // to be after the first non-executed instruction.
+  if (_isSignalFrame)
+    ++pc;
+#endif
+
   // Ask address space object to find unwind sections for this pc.
   UnwindInfoSections sects;
   if (_addressSpace.findUnwindSections(pc, sects)) {

--- a/src/UnwindCursor.hpp
+++ b/src/UnwindCursor.hpp
@@ -2760,15 +2760,7 @@ int UnwindCursor<A, R>::stepThroughSigReturn(Registers_arm64 &) {
     _registers.setRegister(UNW_AARCH64_X0 + i, value);
   }
   _registers.setSP(_addressSpace.get64(sigctx + kOffsetSp));
-
-  // The +1 story is the same as in DwarfInstructions::stepWithDwarf()
-  // (search for "returnAddress + cieInfo.isSignalFrame" or "Return address points to the next instruction").
-  // This is probably not the right place for this because this function is not necessarily used
-  // with DWARF. Need to research whether the other unwind methods have the same +-1 situation or
-  // are off by one.
-  pint_t returnAddress = _addressSpace.get64(sigctx + kOffsetPc);
-  _registers.setIP(returnAddress + 1);
-
+  _registers.setIP(_addressSpace.get64(sigctx + kOffsetPc));
   _isSignalFrame = true;
   return UNW_STEP_SUCCESS;
 }


### PR DESCRIPTION
### Changes
- Revert #30 
- Apply upstream version of the initial patch (#25) - https://github.com/llvm/llvm-project/commit/7b604cdf75fd1c741a15138684ea0e98dca5e46f that should be aarch64-safe