### PR TITLE
Handle x64 linux signal trampoline without relying on DWARF unwind info

### DIFF
--- a/src/UnwindCursor.hpp
+++ b/src/UnwindCursor.hpp
@@ -32,7 +32,7 @@
 
 #if defined(_LIBUNWIND_TARGET_LINUX) &&                                        \
     (defined(_LIBUNWIND_TARGET_AARCH64) || defined(_LIBUNWIND_TARGET_RISCV) || \
-     defined(_LIBUNWIND_TARGET_S390X))
+     defined(_LIBUNWIND_TARGET_S390X) || defined(_LIBUNWIND_TARGET_X86_64))
 #include <errno.h>
 #include <signal.h>
 #include <sys/syscall.h>
@@ -1004,6 +1004,10 @@ private:
 #if defined(_LIBUNWIND_TARGET_S390X)
   bool setInfoForSigReturn(Registers_s390x &);
   int stepThroughSigReturn(Registers_s390x &);
+#endif
+#if defined(_LIBUNWIND_TARGET_X86_64)
+  bool setInfoForSigReturn(Registers_x86_64 &);
+  int stepThroughSigReturn(Registers_x86_64 &);
 #endif
   template <typename Registers> bool setInfoForSigReturn(Registers &) {
     return false;
@@ -2931,6 +2935,96 @@ int UnwindCursor<A, R>::stepThroughSigReturn(Registers_s390x &) {
 }
 #endif // defined(_LIBUNWIND_CHECK_LINUX_SIGRETURN) &&
        // defined(_LIBUNWIND_TARGET_S390X)
+
+#if defined(_LIBUNWIND_CHECK_LINUX_SIGRETURN) &&                               \
+    defined(_LIBUNWIND_TARGET_X86_64)
+template <typename A, typename R>
+bool UnwindCursor<A, R>::setInfoForSigReturn(Registers_x86_64 &) {
+  // Look for the sigreturn trampoline. The trampoline's body is two
+  // specific instructions (see below). Typically the trampoline comes from the
+  // vDSO or from libc.
+  //
+  // This special code path is a fallback that is only used if the trampoline
+  // lacks proper (e.g. DWARF) unwind info.
+  const uint8_t amd64_linux_sigtramp_code[9] = {
+    0x48, 0xc7, 0xc0, 0x0f, 0x00, 0x00, 0x00, // mov rax, 15
+    0x0f, 0x05                                // syscall
+  };
+  const size_t code_size = sizeof(amd64_linux_sigtramp_code);
+
+  // The PC might contain an invalid address if the unwind info is bad, so
+  // directly accessing it could cause a SIGSEGV.
+  unw_word_t pc = static_cast<pint_t>(this->getReg(UNW_REG_IP));
+  if (!isReadableAddr(pc))
+    return false;
+  // If near page boundary, check the next page too.
+  if (((pc + code_size - 1) & 4095) != (pc & 4095) && !isReadableAddr(pc + code_size - 1))
+    return false;
+
+  const uint8_t *pc_ptr = reinterpret_cast<const uint8_t *>(pc);
+  if (memcmp(pc_ptr, amd64_linux_sigtramp_code, code_size))
+    return false;
+
+  _info = {};
+  _info.start_ip = pc;
+  _info.end_ip = pc + code_size;
+  _isSigReturn = true;
+  return true;
+}
+
+template <typename A, typename R>
+int UnwindCursor<A, R>::stepThroughSigReturn(Registers_x86_64 &) {
+  // In the signal trampoline frame, sp points to ucontext:
+  //   struct ucontext {
+  //     unsigned long     uc_flags;
+  //     struct ucontext  *uc_link;
+  //     stack_t           uc_stack; // 24 bytes
+  //     struct sigcontext uc_mcontext;
+  //     ...
+  //   };
+  const pint_t kOffsetSpToSigcontext = (8 + 8 + 24);
+  pint_t sigctx = _registers.getSP() + kOffsetSpToSigcontext;
+
+  // UNW_X86_64_* -> field in struct sigcontext_64.
+  //   struct sigcontext_64 {
+  //     __u64 r8;  // 0
+  //     __u64 r9;  // 1
+  //     __u64 r10; // 2
+  //     __u64 r11; // 3
+  //     __u64 r12; // 4
+  //     __u64 r13; // 5
+  //     __u64 r14; // 6
+  //     __u64 r15; // 7
+  //     __u64 di;  // 8
+  //     __u64 si;  // 9
+  //     __u64 bp;  // 10
+  //     __u64 bx;  // 11
+  //     __u64 dx;  // 12
+  //     __u64 ax;  // 13
+  //     __u64 cx;  // 14
+  //     __u64 sp;  // 15
+  //     __u64 ip;  // 16
+  //     ...
+  //   };
+  const size_t idx_map[17] = {13, 12, 14, 11, 9, 8, 10, 15, 0, 1, 2, 3, 4, 5, 6, 7, 16};
+
+  for (int i = 0; i < 17; ++i) {
+    uint64_t value = _addressSpace.get64(sigctx + idx_map[i] * 8);
+    _registers.setRegister(i, value);
+  }
+
+  // The +1 story is the same as in DwarfInstructions::stepWithDwarf()
+  // (search for "returnAddress + cieInfo.isSignalFrame" or "Return address points to the next instruction").
+  // This is probably not the right place for this because this function is not necessarily used
+  // with DWARF. Need to research whether the other unwind methods have the same +-1 situation or
+  // are off by one.
+  _registers.setIP(_registers.getIP() + 1);
+
+  _isSignalFrame = true;
+  return UNW_STEP_SUCCESS;
+}
+#endif // defined(_LIBUNWIND_CHECK_LINUX_SIGRETURN) &&
+       // defined(_LIBUNWIND_TARGET_X86_64)
 
 template <typename A, typename R> int UnwindCursor<A, R>::step(bool stage2) {
   (void)stage2;


### PR DESCRIPTION
Same thing that libunwind already does for ARM, RISK V, and S390X.

Tested it with musl (modified to produce .eh_frame).

Before:
```
2024.08.06 20:12:34.470414 [ 3269296 ] {} <Fatal> ClientBase: 0.0. inlined from ./build/./src/Common/StackTrace.cpp:349: StackTrace::tryCapture()                                                                                                                                     
2024.08.06 20:12:34.470447 [ 3269296 ] {} <Fatal> ClientBase: 0. ./build/./src/Common/StackTrace.cpp:318: StackTrace::StackTrace(ucontext const&) @ 0x000000000bca7588                                                                                                                
2024.08.06 20:12:34.490829 [ 3269296 ] {} <Fatal> ClientBase: 1. ./build/./src/Common/SignalHandlers.cpp:83: signalHandler(int, siginfo_t*, void*) @ 0x000000000bf046d0
```

After:
```
2024.08.09 00:08:20.838647 [ 3389953 ] {} <Fatal> ClientBase: 0.0. inlined from ./build/./src/Common/StackTrace.cpp:349: StackTrace::tryCapture()
2024.08.09 00:08:20.838685 [ 3389953 ] {} <Fatal> ClientBase: 0. ./build/./src/Common/StackTrace.cpp:318: StackTrace::StackTrace(ucontext const&) @ 0x000000000bca7588
2024.08.09 00:08:20.859259 [ 3389953 ] {} <Fatal> ClientBase: 1. ./build/./src/Common/SignalHandlers.cpp:83: signalHandler(int, siginfo_t*, void*) @ 0x000000000bf046d0
2024.08.09 00:08:20.861179 [ 3389953 ] {} <Fatal> ClientBase: 2. src/signal/x86_64/restore.s:6: __restore_rt @ 0x0000000016850769
2024.08.09 00:08:20.862485 [ 3389953 ] {} <Fatal> ClientBase: 3. src/thread/__syscall_cp.c:11: sccp @ 0x000000001685c5e8
2024.08.09 00:08:20.863526 [ 3389953 ] {} <Fatal> ClientBase: 4. src/thread/__timedwait.c:25: __timedwait_cp @ 0x000000001685d616
2024.08.09 00:08:20.864583 [ 3389953 ] {} <Fatal> ClientBase: 5. src/thread/pthread_cond_timedwait.c:100: pthread_cond_timedwait @ 0x000000001685cf33
2024.08.09 00:08:20.866043 [ 3389953 ] {} <Fatal> ClientBase: 6. ./build/./contrib/llvm-project/libcxx/src/condition_variable.cpp:47: std::condition_variable::wait(std::unique_lock<std::mutex>&) @ 0x00000000167b202f
2024.08.09 00:08:20.880054 [ 3389953 ] {} <Fatal> ClientBase: 7.0. inlined from ./contrib/llvm-project/libcxx/include/vector:553: std::vector<JobWithPriority, std::allocator<JobWithPriority>>::empty[abi:v15007]() const
2024.08.09 00:08:20.880077 [ 3389953 ] {} <Fatal> ClientBase: 7.1. inlined from ./contrib/boost/boost/heap/priority_queue.hpp:179: boost::heap::priority_queue<JobWithPriority, boost::parameter::void_, boost::parameter::void_, boost::parameter::void_, boost::parameter::void_>::empty() const
2024.08.09 00:08:20.880088 [ 3389953 ] {} <Fatal> ClientBase: 7.2. inlined from ./build/./src/Common/ThreadPool.cpp:416: operator()
2024.08.09 00:08:20.880104 [ 3389953 ] {} <Fatal> ClientBase: 7.3. inlined from ./contrib/llvm-project/libcxx/include/__mutex_base:397: void std::condition_variable::wait<ThreadPoolImpl<std::thread>::worker(std::__list_iterator<std::thread, void*>)::'lambda'()>(std::unique_lock<std::mutex>&, ThreadPoolImpl<std::thread>::worker(std::__list_iterator<std::thread, void*>)::'lambda'())
2024.08.09 00:08:20.880120 [ 3389953 ] {} <Fatal> ClientBase: 7. ./build/./src/Common/ThreadPool.cpp:416: ThreadPoolImpl<std::thread>::worker(std::__list_iterator<std::thread, void*>) @ 0x000000000bd2b839
2024.08.09 00:08:20.900100 [ 3389953 ] {} <Fatal> ClientBase: 8.0. inlined from ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:302: std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>::reset[abi:v15007](std::__thread_struct*)
2024.08.09 00:08:20.900119 [ 3389953 ] {} <Fatal> ClientBase: 8.1. inlined from ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:259: ~unique_ptr
2024.08.09 00:08:20.900128 [ 3389953 ] {} <Fatal> ClientBase: 8.2. inlined from ./contrib/llvm-project/libcxx/include/tuple:265: ~__tuple_leaf
2024.08.09 00:08:20.900137 [ 3389953 ] {} <Fatal> ClientBase: 8.3. inlined from ./contrib/llvm-project/libcxx/include/tuple:538: ~tuple
2024.08.09 00:08:20.900157 [ 3389953 ] {} <Fatal> ClientBase: 8.4. inlined from ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:48: std::default_delete<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>>::operator()[abi:v15007](std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>*) const
2024.08.09 00:08:20.900183 [ 3389953 ] {} <Fatal> ClientBase: 8.5. inlined from ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:305: std::unique_ptr<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>, std::default_delete<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>>>::reset[abi:v15007](std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>*)
2024.08.09 00:08:20.900197 [ 3389953 ] {} <Fatal> ClientBase: 8.6. inlined from ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:259: ~unique_ptr
2024.08.09 00:08:20.900208 [ 3389953 ] {} <Fatal> ClientBase: 8. ./contrib/llvm-project/libcxx/include/thread:297: void* std::__thread_proxy[abi:v15007]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>>(void*) @ 0x000000000bd2fd6e
2024.08.09 00:08:20.901351 [ 3389953 ] {} <Fatal> ClientBase: 9. src/thread/pthread_create.c:207: start @ 0x000000001685db15
2024.08.09 00:08:20.902287 [ 3389953 ] {} <Fatal> ClientBase: 10. src/thread/x86_64/clone.s:23: ? @ 0x000000001685f9ad
...
```

https://github.com/ClickHouse/ClickHouse/issues/67921