### PR TITLE
Detect cycles of length 1, like in musl __clone()

### DIFF
--- a/src/UnwindCursor.hpp
+++ b/src/UnwindCursor.hpp
@@ -2938,6 +2938,9 @@ template <typename A, typename R> int UnwindCursor<A, R>::step(bool stage2) {
   if (_unwindInfoMissing)
     return UNW_STEP_END;
 
+  unw_word_t previousIP = getReg(UNW_REG_IP);
+  unw_word_t previousSP = getReg(UNW_REG_SP);
+
   // Use unwinding info to modify register set as if function returned.
   int result;
 #if defined(_LIBUNWIND_CHECK_LINUX_SIGRETURN)
@@ -2966,6 +2969,14 @@ template <typename A, typename R> int UnwindCursor<A, R>::step(bool stage2) {
 
   // update info based on new PC
   if (result == UNW_STEP_SUCCESS) {
+    // Detect cycles of length 1. In particular this happens in musl's
+    // __clone(), which has incorrect DWARF unwind information.
+    // We don't check all registers, so it's not strictly guaranteed that
+    // unwinding would be stuck in a cycle, but seems like a reasonable
+    // heuristic.
+    if (getReg(UNW_REG_SP) == previousSP && getReg(UNW_REG_IP) == previousIP)
+      return UNW_EBADFRAME;
+
     this->setInfoBasedOnIPRegister(true);
     if (_unwindInfoMissing)
       return UNW_STEP_END;


### PR DESCRIPTION
Before:
```
2024.08.08 22:49:04.685716 [ 3329382 ] {} <Fatal> ClientBase: 0.0. inlined from ./build/./src/Common/StackTrace.cpp:349: StackTrace::tryCapture()                                                                                                                                     
2024.08.08 22:49:04.685747 [ 3329382 ] {} <Fatal> ClientBase: 0. ./build/./src/Common/StackTrace.cpp:318: StackTrace::StackTrace(ucontext const&) @ 0x000000000bca7588                                                                                                                
2024.08.08 22:49:04.706201 [ 3329382 ] {} <Fatal> ClientBase: 1. ./build/./src/Common/SignalHandlers.cpp:83: signalHandler(int, siginfo_t*, void*) @ 0x000000000bf046d0                                                                                                               
2024.08.08 22:49:04.708012 [ 3329382 ] {} <Fatal> ClientBase: 2. src/signal/x86_64/restore.s:7: __restore_rt @ 0x000000001684da3c                                                                                                                                                     
2024.08.08 22:49:04.709239 [ 3329382 ] {} <Fatal> ClientBase: 3. src/thread/__syscall_cp.c:18: __syscall_cp @ 0x0000000016858c97                                                                                                                                                      
2024.08.08 22:49:04.710278 [ 3329382 ] {} <Fatal> ClientBase: 4. src/thread/__timedwait.c:25: __timedwait_cp @ 0x0000000016859c7b                                                                                                                                                     
2024.08.08 22:49:04.711344 [ 3329382 ] {} <Fatal> ClientBase: 5. src/thread/pthread_cond_timedwait.c:100: pthread_cond_timedwait @ 0x0000000016859599                                                                                                                                 
2024.08.08 22:49:04.712790 [ 3329382 ] {} <Fatal> ClientBase: 6. ./build/./contrib/llvm-project/libcxx/src/condition_variable.cpp:47: std::condition_variable::wait(std::unique_lock<std::mutex>&) @ 0x00000000167b202f                                                               
2024.08.08 22:49:04.726822 [ 3329382 ] {} <Fatal> ClientBase: 7.0. inlined from ./contrib/llvm-project/libcxx/include/vector:553: std::vector<JobWithPriority, std::allocator<JobWithPriority>>::empty[abi:v15007]() const                                                            
2024.08.08 22:49:04.726845 [ 3329382 ] {} <Fatal> ClientBase: 7.1. inlined from ./contrib/boost/boost/heap/priority_queue.hpp:179: boost::heap::priority_queue<JobWithPriority, boost::parameter::void_, boost::parameter::void_, boost::parameter::void_, boost::parameter::void_>::e
mpty() const                                                                                                                                                                                                                                                                          
2024.08.08 22:49:04.726856 [ 3329382 ] {} <Fatal> ClientBase: 7.2. inlined from ./build/./src/Common/ThreadPool.cpp:416: operator()                                                                                                                                                   
2024.08.08 22:49:04.726875 [ 3329382 ] {} <Fatal> ClientBase: 7.3. inlined from ./contrib/llvm-project/libcxx/include/__mutex_base:397: void std::condition_variable::wait<ThreadPoolImpl<std::thread>::worker(std::__list_iterator<std::thread, void*>)::'lambda'()>(std::unique_lock
<std::mutex>&, ThreadPoolImpl<std::thread>::worker(std::__list_iterator<std::thread, void*>)::'lambda'())                                                                                                                                                                             
2024.08.08 22:49:04.726893 [ 3329382 ] {} <Fatal> ClientBase: 7. ./build/./src/Common/ThreadPool.cpp:416: ThreadPoolImpl<std::thread>::worker(std::__list_iterator<std::thread, void*>) @ 0x000000000bd2b839                                                                          
2024.08.08 22:49:04.746865 [ 3329382 ] {} <Fatal> ClientBase: 8.0. inlined from ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:302: std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>::reset[abi:v15007](std::__thread_struct*)           
2024.08.08 22:49:04.746883 [ 3329382 ] {} <Fatal> ClientBase: 8.1. inlined from ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:259: ~unique_ptr                                                                                                                          
2024.08.08 22:49:04.746894 [ 3329382 ] {} <Fatal> ClientBase: 8.2. inlined from ./contrib/llvm-project/libcxx/include/tuple:265: ~__tuple_leaf                                                                                                                                        
2024.08.08 22:49:04.746905 [ 3329382 ] {} <Fatal> ClientBase: 8.3. inlined from ./contrib/llvm-project/libcxx/include/tuple:538: ~tuple                                                                                                                                               
2024.08.08 22:49:04.746930 [ 3329382 ] {} <Fatal> ClientBase: 8.4. inlined from ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:48: std::default_delete<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<s
td::thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>>::operator()[abi:v15007](std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleIm
pl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>*) const                                                                                                                                                                                  
2024.08.08 22:49:04.746956 [ 3329382 ] {} <Fatal> ClientBase: 8.5. inlined from ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:305: std::unique_ptr<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std:
:thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>, std::default_delete<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void
>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>>>::reset[abi:v15007](std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, P
riority, std::optional<unsigned long>, bool)::'lambda0'()>*)                                                                                                                                                                                                                          
2024.08.08 22:49:04.746969 [ 3329382 ] {} <Fatal> ClientBase: 8.6. inlined from ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:259: ~unique_ptr                                                                                                                          
2024.08.08 22:49:04.746981 [ 3329382 ] {} <Fatal> ClientBase: 8. ./contrib/llvm-project/libcxx/include/thread:297: void* std::__thread_proxy[abi:v15007]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>
::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>>(void*) @ 0x000000000bd2fd6e                                                                                                                                                 
2024.08.08 22:49:04.748099 [ 3329382 ] {} <Fatal> ClientBase: 9. src/thread/pthread_create.c:207: start @ 0x000000001685a161                                                                                                                                                          
2024.08.08 22:49:04.748981 [ 3329382 ] {} <Fatal> ClientBase: 10. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99                                                                                                                                                                
2024.08.08 22:49:04.749856 [ 3329382 ] {} <Fatal> ClientBase: 11. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99                                                                                                                                                                
2024.08.08 22:49:04.750735 [ 3329382 ] {} <Fatal> ClientBase: 12. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99                                                                                                                                                                
2024.08.08 22:49:04.751587 [ 3329382 ] {} <Fatal> ClientBase: 13. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99                                                                                                                                                                
2024.08.08 22:49:04.752442 [ 3329382 ] {} <Fatal> ClientBase: 14. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99                                                                                                                                                                
2024.08.08 22:49:04.753296 [ 3329382 ] {} <Fatal> ClientBase: 15. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99
2024.08.08 22:49:04.754162 [ 3329382 ] {} <Fatal> ClientBase: 16. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99             
2024.08.08 22:49:04.755039 [ 3329382 ] {} <Fatal> ClientBase: 17. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99                                                                                                                                                                
2024.08.08 22:49:04.755896 [ 3329382 ] {} <Fatal> ClientBase: 18. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99                                                                                                                                                                
2024.08.08 22:49:04.756751 [ 3329382 ] {} <Fatal> ClientBase: 19. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99                                                                                                                                                                
2024.08.08 22:49:04.757616 [ 3329382 ] {} <Fatal> ClientBase: 20. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99           
2024.08.08 22:49:04.758492 [ 3329382 ] {} <Fatal> ClientBase: 21. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99                                                                                                                                                                
2024.08.08 22:49:04.759343 [ 3329382 ] {} <Fatal> ClientBase: 22. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99
2024.08.08 22:49:04.760200 [ 3329382 ] {} <Fatal> ClientBase: 23. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99
2024.08.08 22:49:04.761054 [ 3329382 ] {} <Fatal> ClientBase: 24. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99
2024.08.08 22:49:04.761922 [ 3329382 ] {} <Fatal> ClientBase: 25. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99
2024.08.08 22:49:04.762798 [ 3329382 ] {} <Fatal> ClientBase: 26. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99
2024.08.08 22:49:04.763652 [ 3329382 ] {} <Fatal> ClientBase: 27. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99                                                                                                                                                                
2024.08.08 22:49:04.764504 [ 3329382 ] {} <Fatal> ClientBase: 28. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99
2024.08.08 22:49:04.765357 [ 3329382 ] {} <Fatal> ClientBase: 29. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99
2024.08.08 22:49:04.766223 [ 3329382 ] {} <Fatal> ClientBase: 30. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99             
2024.08.08 22:49:04.767097 [ 3329382 ] {} <Fatal> ClientBase: 31. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99
2024.08.08 22:49:04.767950 [ 3329382 ] {} <Fatal> ClientBase: 32. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99                                                                                                                                                                
2024.08.08 22:49:04.768802 [ 3329382 ] {} <Fatal> ClientBase: 33. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99
2024.08.08 22:49:04.769667 [ 3329382 ] {} <Fatal> ClientBase: 34. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99             
2024.08.08 22:49:04.770542 [ 3329382 ] {} <Fatal> ClientBase: 35. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99                                                                                                                                                                
2024.08.08 22:49:04.771394 [ 3329382 ] {} <Fatal> ClientBase: 36. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99                                                                                                                                                                
2024.08.08 22:49:04.772249 [ 3329382 ] {} <Fatal> ClientBase: 37. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99                                                                                                                                                                
2024.08.08 22:49:04.773105 [ 3329382 ] {} <Fatal> ClientBase: 38. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99           
2024.08.08 22:49:04.773974 [ 3329382 ] {} <Fatal> ClientBase: 39. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99                                                                                                                                                                
2024.08.08 22:49:04.774853 [ 3329382 ] {} <Fatal> ClientBase: 40. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99
2024.08.08 22:49:04.775755 [ 3329382 ] {} <Fatal> ClientBase: 41. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99
2024.08.08 22:49:04.776611 [ 3329382 ] {} <Fatal> ClientBase: 42. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99
2024.08.08 22:49:04.777477 [ 3329382 ] {} <Fatal> ClientBase: 43. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99
2024.08.08 22:49:04.778329 [ 3329382 ] {} <Fatal> ClientBase: 44. src/thread/x86_64/clone.s:23: ? @ 0x000000001685be99
```

After:
```
2024.08.09 00:08:20.838647 [ 3389953 ] {} <Fatal> ClientBase: 0.0. inlined from ./build/./src/Common/StackTrace.cpp:349: StackTrace::tryCapture()
2024.08.09 00:08:20.838685 [ 3389953 ] {} <Fatal> ClientBase: 0. ./build/./src/Common/StackTrace.cpp:318: StackTrace::StackTrace(ucontext const&) @ 0x000000000bca7588
2024.08.09 00:08:20.859259 [ 3389953 ] {} <Fatal> ClientBase: 1. ./build/./src/Common/SignalHandlers.cpp:83: signalHandler(int, siginfo_t*, void*) @ 0x000000000bf046d0
2024.08.09 00:08:20.861179 [ 3389953 ] {} <Fatal> ClientBase: 2. src/signal/x86_64/restore.s:6: __restore_rt @ 0x0000000016850769
2024.08.09 00:08:20.862485 [ 3389953 ] {} <Fatal> ClientBase: 3. src/thread/__syscall_cp.c:11: sccp @ 0x000000001685c5e8
2024.08.09 00:08:20.863526 [ 3389953 ] {} <Fatal> ClientBase: 4. src/thread/__timedwait.c:25: __timedwait_cp @ 0x000000001685d616
2024.08.09 00:08:20.864583 [ 3389953 ] {} <Fatal> ClientBase: 5. src/thread/pthread_cond_timedwait.c:100: pthread_cond_timedwait @ 0x000000001685cf33
2024.08.09 00:08:20.866043 [ 3389953 ] {} <Fatal> ClientBase: 6. ./build/./contrib/llvm-project/libcxx/src/condition_variable.cpp:47: std::condition_variable::wait(std::unique_lock<std::mutex>&) @ 0x00000000167b202f
2024.08.09 00:08:20.880054 [ 3389953 ] {} <Fatal> ClientBase: 7.0. inlined from ./contrib/llvm-project/libcxx/include/vector:553: std::vector<JobWithPriority, std::allocator<JobWithPriority>>::empty[abi:v15007]() const
2024.08.09 00:08:20.880077 [ 3389953 ] {} <Fatal> ClientBase: 7.1. inlined from ./contrib/boost/boost/heap/priority_queue.hpp:179: boost::heap::priority_queue<JobWithPriority, boost::parameter::void_, boost::parameter::void_, boost::parameter::void_, boost::parameter::void_>::empty() const
2024.08.09 00:08:20.880088 [ 3389953 ] {} <Fatal> ClientBase: 7.2. inlined from ./build/./src/Common/ThreadPool.cpp:416: operator()
2024.08.09 00:08:20.880104 [ 3389953 ] {} <Fatal> ClientBase: 7.3. inlined from ./contrib/llvm-project/libcxx/include/__mutex_base:397: void std::condition_variable::wait<ThreadPoolImpl<std::thread>::worker(std::__list_iterator<std::thread, void*>)::'lambda'()>(std::unique_lock<std::mutex>&, ThreadPoolImpl<std::thread>::worker(std::__list_iterator<std::thread, void*>)::'lambda'())
2024.08.09 00:08:20.880120 [ 3389953 ] {} <Fatal> ClientBase: 7. ./build/./src/Common/ThreadPool.cpp:416: ThreadPoolImpl<std::thread>::worker(std::__list_iterator<std::thread, void*>) @ 0x000000000bd2b839
2024.08.09 00:08:20.900100 [ 3389953 ] {} <Fatal> ClientBase: 8.0. inlined from ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:302: std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>::reset[abi:v15007](std::__thread_struct*)
2024.08.09 00:08:20.900119 [ 3389953 ] {} <Fatal> ClientBase: 8.1. inlined from ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:259: ~unique_ptr
2024.08.09 00:08:20.900128 [ 3389953 ] {} <Fatal> ClientBase: 8.2. inlined from ./contrib/llvm-project/libcxx/include/tuple:265: ~__tuple_leaf
2024.08.09 00:08:20.900137 [ 3389953 ] {} <Fatal> ClientBase: 8.3. inlined from ./contrib/llvm-project/libcxx/include/tuple:538: ~tuple
2024.08.09 00:08:20.900157 [ 3389953 ] {} <Fatal> ClientBase: 8.4. inlined from ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:48: std::default_delete<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>>::operator()[abi:v15007](std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>*) const
2024.08.09 00:08:20.900183 [ 3389953 ] {} <Fatal> ClientBase: 8.5. inlined from ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:305: std::unique_ptr<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>, std::default_delete<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>>>::reset[abi:v15007](std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>*)
2024.08.09 00:08:20.900197 [ 3389953 ] {} <Fatal> ClientBase: 8.6. inlined from ./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:259: ~unique_ptr
2024.08.09 00:08:20.900208 [ 3389953 ] {} <Fatal> ClientBase: 8. ./contrib/llvm-project/libcxx/include/thread:297: void* std::__thread_proxy[abi:v15007]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void ThreadPoolImpl<std::thread>::scheduleImpl<void>(std::function<void ()>, Priority, std::optional<unsigned long>, bool)::'lambda0'()>>(void*) @ 0x000000000bd2fd6e
2024.08.09 00:08:20.901351 [ 3389953 ] {} <Fatal> ClientBase: 9. src/thread/pthread_create.c:207: start @ 0x000000001685db15
2024.08.09 00:08:20.902287 [ 3389953 ] {} <Fatal> ClientBase: 10. src/thread/x86_64/clone.s:23: ? @ 0x000000001685f9ad
```

https://github.com/ClickHouse/ClickHouse/issues/67921