### PR TITLE
Implement async-signal-safe lock for DwarfFDECache

### DIFF
--- a/src/UnwindCursor.hpp
+++ b/src/UnwindCursor.hpp
@@ -116,7 +116,7 @@ private:
 
   // These fields are all static to avoid needing an initializer.
   // There is only one instance of this class per process.
-  static RWMutex _lock;
+  static LockFreeRWMutex _lock;
 #ifdef __APPLE__
   static void dyldUnloadHook(const struct mach_header *mh, intptr_t slide);
   static bool _registeredForDyldUnloads;
@@ -143,7 +143,7 @@ template <typename A>
 typename DwarfFDECache<A>::entry DwarfFDECache<A>::_initialBuffer[64];
 
 template <typename A>
-RWMutex DwarfFDECache<A>::_lock;
+LockFreeRWMutex DwarfFDECache<A>::_lock;
 
 #ifdef __APPLE__
 template <typename A>


### PR DESCRIPTION
There are at least three types of stack unwinding in ClickHouse:

1. Signal triggered unwinding

SIGUSR1: Used by the CPU Profiler
SIGUSR2: Used by the Real Profiler
SIGTRIM: Used by system.stack_trace

2. Jemalloc profile unwinding

3. Exception unwinding

During stack unwinding, libunwind manipulates the `DwarfFDECache` which acquires a read-write mutex (RWMutex). This is not async-signal-safe and can lead to serious issues. In particular, a signal handler might try to acquire the mutex while current thread is already in the process of unwinding and trying to acquire the same mutex , potentially leading to corruption of the mutex state and making debugging extremely difficult. A deadlock occurring during stack unwinding typically results in a "stop-the-world" situation.

An intuitive way to solve this problem is to block related signals before unwinding stack and unblock them later. However it's almost impossible to unblock signals later after exception unwinding.

Another way is to remove the use of pthread rw lock which is not async-signal-safe. This PR implements a simple lockfree RWMutex which should be good enough for stack unwinding purpose. It has been verified across a cluster of over 100 nodes. Prior to this implementation, the system experienced node deadlocks every 3-5 days. After applying the PR, the cluster has now been stable for two weeks without any reported issues.

Similar issue: https://github.com/ClickHouse/ClickHouse/issues/69904