### PR TITLE
Revert "Implement async-signal-safe lock for DwarfFDECache"

### DIFF
--- a/src/RWMutex.hpp
+++ b/src/RWMutex.hpp
@@ -16,11 +16,7 @@
 #if defined(_WIN32)
 #include <windows.h>
 #elif !defined(_LIBUNWIND_HAS_NO_THREADS)
-#include <limits.h>
 #include <pthread.h>
-#include <stdatomic.h>
-#include <stdlib.h>
-#include <sched.h>
 #if defined(__ELF__) && defined(_LIBUNWIND_LINK_PTHREAD_LIB)
 #pragma comment(lib, "pthread")
 #endif
@@ -31,14 +27,6 @@ namespace libunwind {
 #if defined(_LIBUNWIND_HAS_NO_THREADS)
 
 class _LIBUNWIND_HIDDEN RWMutex {
-public:
-  bool lock_shared() { return true; }
-  bool unlock_shared() { return true; }
-  bool lock() { return true; }
-  bool unlock() { return true; }
-};
-
-class _LIBUNWIND_HIDDEN LockFreeRWMutex {
 public:
   bool lock_shared() { return true; }
   bool unlock_shared() { return true; }
@@ -120,86 +108,6 @@ private:
 };
 
 #endif
-
-/// Simple lock-free reader-writer lock with writer preference.
-/// It's supposed to be async-signal-safe.
-class LockFreeRWMutex {
-public:
-  LockFreeRWMutex() {
-    atomic_init(&state, 0);
-    atomic_init(&waiting_writers, 0);
-  }
-
-  bool lock_shared() {
-    while (true) {
-      int current_state = atomic_load(&state);
-      if (current_state < 0 || current_state >= INT_MAX ||
-          atomic_load(&waiting_writers) > 0) {
-        sched_yield();
-        continue;
-      }
-
-      if (atomic_compare_exchange_weak(&state, &current_state,
-                                       current_state + 1)) {
-        return true;
-      }
-      sched_yield();
-    }
-  }
-
-  bool unlock_shared() {
-    int current_state = atomic_fetch_sub(&state, 1);
-    if (current_state <= 0) {
-      abort();
-    }
-    return true;
-  }
-
-  bool lock() {
-    while (true) {
-      int current_waiting_writers = atomic_load(&waiting_writers);
-      if (current_waiting_writers == INT_MAX) {
-        sched_yield();
-        continue;
-      }
-
-      if (atomic_compare_exchange_weak(&waiting_writers,
-                                       &current_waiting_writers,
-                                       current_waiting_writers + 1)) {
-        break;
-      }
-      sched_yield();
-    }
-
-    while (true) {
-      int expected = 0;
-      if (atomic_compare_exchange_weak(&state, &expected, -1)) {
-        atomic_fetch_sub(&waiting_writers, 1);
-        return true;
-      }
-      sched_yield();
-    }
-  }
-
-  bool unlock() {
-    int current_state = atomic_load(&state);
-    if (current_state != -1) {
-        abort();
-    }
-    atomic_store(&state, 0);
-    return true;
-  }
-
-private:
-  // Lock state:
-  // - Positive: Number of active readers
-  // - Zero: Unlocked
-  // - Negative (-1): Writer holding the lock
-  atomic_int state;
-
-  // Number of writers waiting for the lock
-  atomic_int waiting_writers;
-};
 
 } // namespace libunwind
 

--- a/src/UnwindCursor.hpp
+++ b/src/UnwindCursor.hpp
@@ -116,7 +116,7 @@ private:
 
   // These fields are all static to avoid needing an initializer.
   // There is only one instance of this class per process.
-  static LockFreeRWMutex _lock;
+  static RWMutex _lock;
 #ifdef __APPLE__
   static void dyldUnloadHook(const struct mach_header *mh, intptr_t slide);
   static bool _registeredForDyldUnloads;
@@ -143,7 +143,7 @@ template <typename A>
 typename DwarfFDECache<A>::entry DwarfFDECache<A>::_initialBuffer[64];
 
 template <typename A>
-LockFreeRWMutex DwarfFDECache<A>::_lock;
+RWMutex DwarfFDECache<A>::_lock;
 
 #ifdef __APPLE__
 template <typename A>


### PR DESCRIPTION
Revert https://github.com/ClickHouse/libunwind/pull/34

The `#include <stdatomic.h>` fails in clickhouse's freebsd build: https://s3.amazonaws.com/clickhouse-test-reports/PRs/76178/a251d6e77bddd4654546ca48f5d186fb233a3771//build_amd_freebsd/build_log.log because of the usual kind of C/C++ nonsense (need to define _Bool in stdbool.h in sysroot?). Since this whole code path doesn't do anything in clickhouse (because `_LIBUNWIND_NO_HEAP` is defined, disabling DwarfFDECache), let's just revert it.